### PR TITLE
Fix CSS for Google Docs XBlock

### DIFF
--- a/lms/static/sass/_developer.scss
+++ b/lms/static/sass/_developer.scss
@@ -286,3 +286,30 @@
     }
   }
 }
+
+
+// GOOGLE DOCS XBLOCK overrides
+
+.google-docs-xblock-wrapper {
+  height: 100%;
+}
+
+.xblock-render .xblock-student_view-google-document {
+  position: relative !important;
+}
+
+.xblock-student_view-google-document {
+  position: fixed !important;
+  left: 0 !important;
+  top: 0 !important;
+  width: 100% !important;
+  height: 100% !important;
+  padding: 0 !important;
+  border: 0 none !important;
+
+  iframe {
+    border: 0 none;
+    height: 100%;
+    width: 100%;
+  }
+}


### PR DESCRIPTION
We need this CSS fix to be able to show the doc in fullscreen in
an iframe in MIT CRE app.
