### PR TITLE
Remove uncustomizable xblocks, disable menus and unit name editing for instructor, add advisory note

### DIFF
--- a/cms/djangoapps/contentstore/views/component.py
+++ b/cms/djangoapps/contentstore/views/component.py
@@ -127,6 +127,16 @@ def container_handler(request, usage_key_string):
                     break
                 index += 1
 
+            # MIT override - only staff can edit component name
+            if not request.user.is_staff:
+                try:
+                    CONTAINER_TEMPLATES.remove('xblock-string-field-editor')
+                except ValueError:
+                    pass
+            # once the template is removed, without restarting the studio, it won't be rendered
+            elif 'xblock-string-field-editor' not in CONTAINER_TEMPLATES:
+                CONTAINER_TEMPLATES.append('xblock-string-field-editor')
+
             return render_to_response('container.html', {
                 'context_course': course,  # Needed only for display of menus at top of page.
                 'action': action,

--- a/cms/djangoapps/contentstore/views/component.py
+++ b/cms/djangoapps/contentstore/views/component.py
@@ -26,6 +26,7 @@ from contentstore.views.item import create_xblock_info, add_container_page_publi
 from opaque_keys.edx.keys import UsageKey
 
 from student.auth import has_course_author_access
+from student.roles import GlobalStaff
 from django.utils.translation import ugettext as _
 from xblock_django.models import XBlockDisableConfig
 
@@ -52,11 +53,13 @@ CONTAINER_TEMPLATES = [
 ]
 
 
-def _advanced_component_types():
+def _advanced_component_types(request):
     """
     Return advanced component types which can be created.
     """
     disabled_create_block_types = XBlockDisableConfig.disabled_create_block_types()
+    if not request.user.is_staff:
+        disabled_create_block_types.extend(settings.MIT_INSTRUCTOR_UNSUPPORTED_BLOCK_TYPES)
     return [c_type for c_type in ADVANCED_COMPONENT_TYPES if c_type not in disabled_create_block_types]
 
 
@@ -91,7 +94,7 @@ def container_handler(request, usage_key_string):
             except ItemNotFoundError:
                 return HttpResponseBadRequest()
 
-            component_templates = get_component_templates(course)
+            component_templates = get_component_templates(request, course)
             ancestor_xblocks = []
             parent = get_parent_xblock(xblock)
             action = request.GET.get('action', 'view')
@@ -158,7 +161,7 @@ def container_handler(request, usage_key_string):
         return HttpResponseBadRequest("Only supports HTML requests")
 
 
-def get_component_templates(courselike, library=False):
+def get_component_templates(request, courselike, library=False):
     """
     Returns the applicable component templates that can be used by the specified course or library.
     """
@@ -262,7 +265,7 @@ def get_component_templates(courselike, library=False):
     # enabled for the course.
     course_advanced_keys = courselike.advanced_modules
     advanced_component_templates = {"type": "advanced", "templates": [], "display_name": _("Advanced")}
-    advanced_component_types = _advanced_component_types()
+    advanced_component_types = _advanced_component_types(request)
     # Set component types according to course policy file
     if isinstance(course_advanced_keys, list):
         for category in course_advanced_keys:

--- a/cms/djangoapps/contentstore/views/component.py
+++ b/cms/djangoapps/contentstore/views/component.py
@@ -26,7 +26,6 @@ from contentstore.views.item import create_xblock_info, add_container_page_publi
 from opaque_keys.edx.keys import UsageKey
 
 from student.auth import has_course_author_access
-from student.roles import GlobalStaff
 from django.utils.translation import ugettext as _
 from xblock_django.models import XBlockDisableConfig
 

--- a/cms/djangoapps/contentstore/views/course.py
+++ b/cms/djangoapps/contentstore/views/course.py
@@ -114,6 +114,13 @@ __all__ = ['course_info_handler', 'course_handler', 'course_listing',
            'textbooks_list_handler', 'textbooks_detail_handler',
            'group_configurations_list_handler', 'group_configurations_detail_handler']
 
+COURSE_OUTLINE_TEMPLATES = [
+    'course-outline',
+    'basic-modal', 'modal-button', 'course-outline-modal',
+    'due-date-editor', 'release-date-editor', 'grading-editor', 'publish-editor', 'staff-lock-editor',
+    'xblock-string-field-editor', 'verification-access-editor', 'timed-examination-preference-editor',
+    'access-editor', 'settings-modal-tabs'
+]
 
 class AccessListFallback(Exception):
     """
@@ -603,6 +610,16 @@ def course_index(request, course_key):
         deprecated_block_names = [block.name for block in deprecated_xblocks()]
         deprecated_blocks_info = _deprecated_blocks_info(course_module, deprecated_block_names)
 
+        # MIT override - only staff can edit component name
+        if not request.user.is_staff:
+            try:
+                COURSE_OUTLINE_TEMPLATES.remove('xblock-string-field-editor')
+            except ValueError:
+                pass
+        # once the template is removed, without restarting the studio, it won't be rendered
+        elif 'xblock-string-field-editor' not in COURSE_OUTLINE_TEMPLATES:
+                COURSE_OUTLINE_TEMPLATES.append('xblock-string-field-editor')
+
         return render_to_response('course_outline.html', {
             'context_course': course_module,
             'lms_link': lms_link,
@@ -614,6 +631,7 @@ def course_index(request, course_key):
             'settings_url': settings_url,
             'reindex_link': reindex_link,
             'deprecated_blocks_info': deprecated_blocks_info,
+            'templates': COURSE_OUTLINE_TEMPLATES,
             'notification_dismiss_url': reverse_course_url(
                 'course_notifications_handler',
                 current_action.course_key,

--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -1195,3 +1195,18 @@ PARTNER_SUPPORT_EMAIL = ''
 
 # Affiliate cookie tracking
 AFFILIATE_COOKIE_NAME = 'affiliate_id'
+
+
+############################ MIT settings ###################################
+
+# Xblock types which only MIT admin (staff user) can add
+MIT_INSTRUCTOR_UNSUPPORTED_BLOCK_TYPES = [
+    'mit_cre_timeline',
+    'charts',
+    'community_eyes',
+    'developers_eyes',
+    'network_chart',
+    'multibar_charts',
+    'neighborhood_dynamics',
+    'building_simulation'
+]

--- a/cms/static/sass/_developer.scss
+++ b/cms/static/sass/_developer.scss
@@ -29,6 +29,3 @@
 {
 	display: block !important;
 }
-.unit-location.note {
-  display: block;
-}

--- a/cms/static/sass/_developer.scss
+++ b/cms/static/sass/_developer.scss
@@ -12,9 +12,9 @@
 .unit-location,
 .wrapper-release.bar-mod-content,
 .wrapper-visibility.bar-mod-content,
-.mast.has-actions .nav-actions,
 .list-courses .item-actions.course-actions,
 .status-release,
+.nav-actions,
 [data-type="html"].add-xblock-component-button,
 [data-type="video"].add-xblock-component-button,
 [data-type="discussion"].add-xblock-component-button,
@@ -25,8 +25,10 @@
   display: none !important;
 }
 
-.new-component-templates.new-component-advanced 
+.new-component-templates.new-component-advanced
 {
 	display: block !important;
 }
-
+.unit-location.note {
+  display: block;
+}

--- a/cms/static/sass/_developer.scss
+++ b/cms/static/sass/_developer.scss
@@ -14,7 +14,6 @@
 .wrapper-visibility.bar-mod-content,
 .list-courses .item-actions.course-actions,
 .status-release,
-//.nav-actions,
 [data-type="html"].add-xblock-component-button,
 [data-type="video"].add-xblock-component-button,
 [data-type="discussion"].add-xblock-component-button,

--- a/cms/static/sass/_developer.scss
+++ b/cms/static/sass/_developer.scss
@@ -12,6 +12,7 @@
 .unit-location,
 .wrapper-release.bar-mod-content,
 .wrapper-visibility.bar-mod-content,
+.nav-actions,
 .list-courses .item-actions.course-actions,
 .status-release,
 [data-type="html"].add-xblock-component-button,
@@ -27,4 +28,8 @@
 .new-component-templates.new-component-advanced
 {
 	display: block !important;
+}
+// asset_index.html display file upload for MIT admin
+.nav-actions.upload-file {
+  display: block !important;
 }

--- a/cms/static/sass/_developer.scss
+++ b/cms/static/sass/_developer.scss
@@ -14,7 +14,7 @@
 .wrapper-visibility.bar-mod-content,
 .list-courses .item-actions.course-actions,
 .status-release,
-.nav-actions,
+//.nav-actions,
 [data-type="html"].add-xblock-component-button,
 [data-type="video"].add-xblock-component-button,
 [data-type="discussion"].add-xblock-component-button,

--- a/cms/static/sass/views/_container.scss
+++ b/cms/static/sass/views/_container.scss
@@ -261,12 +261,13 @@
     }
 
     // location widget
-    .unit-location, .library-location {
+    .unit-location, .library-location{
       @extend %bar-module;
       border-top: none;
 
-      .wrapper-unit-id, .wrapper-library-id {
-
+      .wrapper-unit-id, .wrapper-library-id,
+      // wrapper-unit-note is MIT addition
+      .wrapper-unit-note {
         .unit-id-value, .library-id-value {
           @extend %status-value-base;
           display: inline-block;
@@ -328,6 +329,12 @@
           padding: 3px 6px;
         }
       }
+    }
+
+    // addition for MIT case
+    .unit-note {
+      @extend %bar-module-red;
+      border-top: none;
     }
   }
 }

--- a/cms/templates/asset_index.html
+++ b/cms/templates/asset_index.html
@@ -34,13 +34,14 @@
 <%block name="content">
 
 <div class="wrapper-mast wrapper">
+
     <header class="mast has-actions has-subtitle">
         <h1 class="page-header">
             <small class="subtitle">${_("Content")}</small>
             <span class="sr">&gt; </span>${_("Files & Uploads")}
         </h1>
-
-        <nav class="nav-actions" aria-label="${_('Page Actions')}">
+        %if user.is_staff:
+        <nav class="nav-actions upload-file" aria-label="${_('Page Actions')}">
             <h3 class="sr">${_("Page Actions")}</h3>
             <ul>
                 <li class="nav-item">
@@ -48,6 +49,7 @@
                 </li>
             </ul>
         </nav>
+        %endif
     </header>
 </div>
 

--- a/cms/templates/asset_index.html
+++ b/cms/templates/asset_index.html
@@ -39,8 +39,7 @@
             <small class="subtitle">${_("Content")}</small>
             <span class="sr">&gt; </span>${_("Files & Uploads")}
         </h1>
-        ## MIT override
-        %if user.is_staff:
+
         <nav class="nav-actions" aria-label="${_('Page Actions')}">
             <h3 class="sr">${_("Page Actions")}</h3>
             <ul>
@@ -49,7 +48,6 @@
                 </li>
             </ul>
         </nav>
-        %endif
     </header>
 </div>
 

--- a/cms/templates/asset_index.html
+++ b/cms/templates/asset_index.html
@@ -39,7 +39,8 @@
             <small class="subtitle">${_("Content")}</small>
             <span class="sr">&gt; </span>${_("Files & Uploads")}
         </h1>
-
+        ## MIT override
+        %if user.is_staff:
         <nav class="nav-actions" aria-label="${_('Page Actions')}">
             <h3 class="sr">${_("Page Actions")}</h3>
             <ul>
@@ -48,6 +49,7 @@
                 </li>
             </ul>
         </nav>
+        %endif
     </header>
 </div>
 

--- a/cms/templates/container.html
+++ b/cms/templates/container.html
@@ -72,7 +72,9 @@ from openedx.core.djangolib.markup import HTML, Text
                 <h1 class="page-header-title xblock-field-value incontext-editor-value"><span class="title-value">${xblock.display_name_with_default}</span></h1>
             </div>
         </div>
-            <nav class="nav-actions" aria-label="${_('Page Actions')}">
+        ## MIT override
+        %if user.is_staff:
+        <nav class="nav-actions" aria-label="${_('Page Actions')}">
             <h3 class="sr">${_("Page Actions")}</h3>
             <ul>
                 % if is_unit_page:
@@ -96,6 +98,7 @@ from openedx.core.djangolib.markup import HTML, Text
                 % endif
             </ul>
         </nav>
+        %endif
     </header>
 </div>
 

--- a/cms/templates/container.html
+++ b/cms/templates/container.html
@@ -60,7 +60,7 @@ from openedx.core.djangolib.markup import HTML, Text
                     <%
                     ancestor_url = xblock_studio_url(ancestor)
                     %>
-                    % if ancestor_url:
+                    % if ancestor_url and user.is_staff:
                         <a href="${ancestor_url}" class="navigation-item navigation-link navigation-parent">${ancestor.display_name_with_default}</a>
                     % else:
                         <span class="navigation-item navigation-parent">${ancestor.display_name_with_default}</span>
@@ -72,8 +72,7 @@ from openedx.core.djangolib.markup import HTML, Text
                 <h1 class="page-header-title xblock-field-value incontext-editor-value"><span class="title-value">${xblock.display_name_with_default}</span></h1>
             </div>
         </div>
-
-        <nav class="nav-actions" aria-label="${_('Page Actions')}">
+            <nav class="nav-actions" aria-label="${_('Page Actions')}">
             <h3 class="sr">${_("Page Actions")}</h3>
             <ul>
                 % if is_unit_page:
@@ -151,6 +150,19 @@ from openedx.core.djangolib.markup import HTML, Text
                             <h5 class="title">${_("Location in Course Outline")}</h5>
                             <div class="wrapper-unit-overview outline outline-simple">
                             </div>
+                        </div>
+                    </div>
+                    ##   MIT add note override
+                    <div class="unit-note">
+                        <h4 class="bar-mod-title">Note:</h4>
+                        <div class="wrapper-unit-note bar-mod-content">
+                            <p class="unit-id">
+                                By clicking on the <b>Publish</b> button all of the contents showing on left get published together.
+                                Once published, contents become visible in the content list for the baseline showing at the top of this page.
+                                This makes these materials available for other instructors to use in additional case studies for the baseline.
+                                Once published, the only way to “un-publish” is to delete the content on left.
+                                Updates to published content go into effect whenever you publish.
+                            </p>
                         </div>
                     </div>
                 % endif

--- a/cms/templates/container.html
+++ b/cms/templates/container.html
@@ -72,8 +72,6 @@ from openedx.core.djangolib.markup import HTML, Text
                 <h1 class="page-header-title xblock-field-value incontext-editor-value"><span class="title-value">${xblock.display_name_with_default}</span></h1>
             </div>
         </div>
-        ## MIT override
-        %if user.is_staff:
         <nav class="nav-actions" aria-label="${_('Page Actions')}">
             <h3 class="sr">${_("Page Actions")}</h3>
             <ul>
@@ -98,7 +96,6 @@ from openedx.core.djangolib.markup import HTML, Text
                 % endif
             </ul>
         </nav>
-        %endif
     </header>
 </div>
 

--- a/cms/templates/course_info.html
+++ b/cms/templates/course_info.html
@@ -35,6 +35,8 @@ from openedx.core.djangolib.js_utils import (
 
 <%block name="content">
   <div class="wrapper-mast wrapper">
+    ## MIT override
+    %if user.is_staff:
     <header class="mast has-actions has-subtitle">
       <h1 class="page-header">
         <small class="subtitle">${_("Content")}</small>
@@ -50,6 +52,7 @@ from openedx.core.djangolib.js_utils import (
         </ul>
       </nav>
     </header>
+    %endif
   </div>
 
   <div class="wrapper-content wrapper">

--- a/cms/templates/course_outline.html
+++ b/cms/templates/course_outline.html
@@ -26,7 +26,7 @@ from openedx.core.djangolib.markup import HTML, Text
 
 <%block name="header_extras">
 <link rel="stylesheet" type="text/css" href="${static.url('js/vendor/timepicker/jquery.timepicker.css')}" />
-% for template_name in ['course-outline', 'xblock-string-field-editor', 'basic-modal', 'modal-button', 'course-outline-modal', 'due-date-editor', 'release-date-editor', 'grading-editor', 'publish-editor', 'staff-lock-editor', 'verification-access-editor', 'timed-examination-preference-editor', 'access-editor', 'settings-modal-tabs']:
+% for template_name in templates:
 <script type="text/template" id="${template_name}-tpl">
     <%static:include path="js/${template_name}.underscore" />
 </script>

--- a/cms/templates/course_outline.html
+++ b/cms/templates/course_outline.html
@@ -116,7 +116,8 @@ from openedx.core.djangolib.markup import HTML, Text
             <small class="subtitle">${_("Content")}</small>
             <span class="sr">&gt; </span>${_("Your Media Units")}
         </h1>
-
+        ## MIT override
+        %if user.is_staff:
         <nav class="nav-actions" aria-label="${_('Page Actions')}">
             <h3 class="sr">${_("Page Actions")}</h3>
             <ul>
@@ -144,6 +145,7 @@ from openedx.core.djangolib.markup import HTML, Text
                 </li>
             </ul>
         </nav>
+        %endif
     </header>
 </div>
 

--- a/cms/templates/index.html
+++ b/cms/templates/index.html
@@ -26,6 +26,8 @@ from openedx.core.djangolib.markup import HTML, Text
     <nav class="nav-actions" aria-label="${_('Page Actions')}">
       <h3 class="sr">${_("Page Actions")}</h3>
       <ul>
+        ## MIT override
+        %if user.is_staff:
         <li class="nav-item">
           % if course_creator_status=='granted':
           <a href="#" class="button new-button new-course-button"><span class="icon fa fa-plus icon-inline" aria-hidden="true"></span>
@@ -44,6 +46,7 @@ from openedx.core.djangolib.markup import HTML, Text
             ${_("New Program")}</a>
           % endif
         </li>
+        %endif
       </ul>
     </nav>
     % endif

--- a/cms/templates/manage_users.html
+++ b/cms/templates/manage_users.html
@@ -13,32 +13,31 @@ from openedx.core.djangolib.js_utils import (
 <%namespace name='static' file='static_content.html'/>
 
 <%block name="header_extras">
-<script type="text/template" id="team-member-tpl">
-    <%static:include path="js/team-member.underscore" />
-</script>
+    <div class="wrapper-mast wrapper">
+    <header class="mast has-actions has-subtitle">
+        <h1 class="page-header">
+            <small class="subtitle">${_("Settings")}</small>
+            <span class="sr">&gt; </span>${_("Course Team")}
+        </h1>
+        <nav class="nav-actions" aria-label="${_('Page Actions')}">
+            <h3 class="sr">${_("Page Actions")}</h3>
+            <ul>
+                %if allow_actions:
+                    <li class="nav-item">
+                        <a href="#" class="button new-button create-user-button"><span class="icon fa fa-plus" aria-hidden="true"></span> ${_("New Team Member")}</a>
+                    </li>
+                %endif
+            </ul>
+        </nav>
+    </header>
+    </div>
 </%block>
 
 <%block name="content">
 
-<div class="wrapper-mast wrapper">
-  <header class="mast has-actions has-subtitle">
-    <h1 class="page-header">
-      <small class="subtitle">${_("Settings")}</small>
-      <span class="sr">&gt; </span>${_("Course Team")}
-    </h1>
-
-    <nav class="nav-actions" aria-label="${_('Page Actions')}">
-      <h3 class="sr">${_("Page Actions")}</h3>
-      <ul>
-        %if allow_actions:
-        <li class="nav-item">
-          <a href="#" class="button new-button create-user-button"><span class="icon fa fa-plus" aria-hidden="true"></span> ${_("New Team Member")}</a>
-        </li>
-        %endif
-      </ul>
-    </nav>
-  </header>
-</div>
+<script type="text/template" id="team-member-tpl">
+    <%static:include path="js/team-member.underscore" />
+</script>
 
 <div class="wrapper-content wrapper">
   <section class="content">

--- a/cms/templates/manage_users.html
+++ b/cms/templates/manage_users.html
@@ -13,31 +13,32 @@ from openedx.core.djangolib.js_utils import (
 <%namespace name='static' file='static_content.html'/>
 
 <%block name="header_extras">
-    <div class="wrapper-mast wrapper">
-    <header class="mast has-actions has-subtitle">
-        <h1 class="page-header">
-            <small class="subtitle">${_("Settings")}</small>
-            <span class="sr">&gt; </span>${_("Course Team")}
-        </h1>
-        <nav class="nav-actions" aria-label="${_('Page Actions')}">
-            <h3 class="sr">${_("Page Actions")}</h3>
-            <ul>
-                %if allow_actions:
-                    <li class="nav-item">
-                        <a href="#" class="button new-button create-user-button"><span class="icon fa fa-plus" aria-hidden="true"></span> ${_("New Team Member")}</a>
-                    </li>
-                %endif
-            </ul>
-        </nav>
-    </header>
-    </div>
+<script type="text/template" id="team-member-tpl">
+    <%static:include path="js/team-member.underscore" />
+</script>
 </%block>
 
 <%block name="content">
 
-<script type="text/template" id="team-member-tpl">
-    <%static:include path="js/team-member.underscore" />
-</script>
+<div class="wrapper-mast wrapper">
+  <header class="mast has-actions has-subtitle">
+    <h1 class="page-header">
+      <small class="subtitle">${_("Settings")}</small>
+      <span class="sr">&gt; </span>${_("Course Team")}
+    </h1>
+
+    <nav class="nav-actions" aria-label="${_('Page Actions')}">
+      <h3 class="sr">${_("Page Actions")}</h3>
+      <ul>
+        %if allow_actions:
+        <li class="nav-item">
+          <a href="#" class="button new-button create-user-button"><span class="icon fa fa-plus" aria-hidden="true"></span> ${_("New Team Member")}</a>
+        </li>
+        %endif
+      </ul>
+    </nav>
+  </header>
+</div>
 
 <div class="wrapper-content wrapper">
   <section class="content">

--- a/cms/templates/widgets/header.html
+++ b/cms/templates/widgets/header.html
@@ -50,96 +50,96 @@
           <span class="course-title" title="${context_course.display_name_with_default}">${context_course.display_name_with_default}</span>
         </a>
       </h2>
-##         MIT override
+          ## MIT override
           %if user.is_staff:
-          <nav class="nav-course nav-dd ui-left" aria-label="${_('Course')}">
-        <h2 class="sr">${_("Course Navigation")}</h2>
-        <ol>
-          <li class="nav-item nav-course-courseware">
-            <h3 class="title"><span class="label"><span class="label-prefix sr">${_("Course")} </span>${_("Content")}</span> <span class="icon fa fa-caret-down ui-toggle-dd" aria-hidden="true"></span></h3>
+                <nav class="nav-course nav-dd ui-left" aria-label="${_('Course')}">
+                <h2 class="sr">${_("Course Navigation")}</h2>
+                <ol>
+                  <li class="nav-item nav-course-courseware">
+                    <h3 class="title"><span class="label"><span class="label-prefix sr">${_("Course")} </span>${_("Content")}</span> <span class="icon fa fa-caret-down ui-toggle-dd" aria-hidden="true"></span></h3>
 
-            <div class="wrapper wrapper-nav-sub">
-              <div class="nav-sub">
-                <ul>
-                  <li class="nav-item nav-course-courseware-outline">
-                    <a href="${index_url}">${_("Outline")}</a>
+                    <div class="wrapper wrapper-nav-sub">
+                      <div class="nav-sub">
+                        <ul>
+                          <li class="nav-item nav-course-courseware-outline">
+                            <a href="${index_url}">${_("Outline")}</a>
+                          </li>
+                          <li class="nav-item nav-course-courseware-updates">
+                            <a href="${course_info_url}">${_("Updates")}</a>
+                          </li>
+                          <li class="nav-item nav-course-courseware-pages">
+                            <a href="${tabs_url}">${_("Pages")}</a>
+                          </li>
+                          <li class="nav-item nav-course-courseware-uploads">
+                            <a href="${assets_url}">${_("Files & Uploads")}</a>
+                          </li>
+                          <li class="nav-item nav-course-courseware-textbooks">
+                            <a href="${textbooks_url}">${_("Textbooks")}</a>
+                          </li>
+                          % if context_course.video_pipeline_configured:
+                          <li class="nav-item nav-course-courseware-videos">
+                            <a href="${videos_url}">${_("Video Uploads")}</a>
+                          </li>
+                          % endif
+                        </ul>
+                      </div>
+                    </div>
                   </li>
-                  <li class="nav-item nav-course-courseware-updates">
-                    <a href="${course_info_url}">${_("Updates")}</a>
-                  </li>
-                  <li class="nav-item nav-course-courseware-pages">
-                    <a href="${tabs_url}">${_("Pages")}</a>
-                  </li>
-                  <li class="nav-item nav-course-courseware-uploads">
-                    <a href="${assets_url}">${_("Files & Uploads")}</a>
-                  </li>
-                  <li class="nav-item nav-course-courseware-textbooks">
-                    <a href="${textbooks_url}">${_("Textbooks")}</a>
-                  </li>
-                  % if context_course.video_pipeline_configured:
-                  <li class="nav-item nav-course-courseware-videos">
-                    <a href="${videos_url}">${_("Video Uploads")}</a>
-                  </li>
-                  % endif
-                </ul>
-              </div>
-            </div>
-          </li>
 
-          <li class="nav-item nav-course-settings">
-            <h3 class="title"><span class="label"><span class="label-prefix sr">${_("Course")} </span>${_("Settings")}</span> <span class="icon fa fa-caret-down ui-toggle-dd" aria-hidden="true"></span></h3>
+                  <li class="nav-item nav-course-settings">
+                    <h3 class="title"><span class="label"><span class="label-prefix sr">${_("Course")} </span>${_("Settings")}</span> <span class="icon fa fa-caret-down ui-toggle-dd" aria-hidden="true"></span></h3>
 
-            <div class="wrapper wrapper-nav-sub">
-              <div class="nav-sub">
-                <ul>
-                  <li class="nav-item nav-course-settings-schedule">
-                    <a href="${settings_url}">${_("Schedule & Details")}</a>
+                    <div class="wrapper wrapper-nav-sub">
+                      <div class="nav-sub">
+                        <ul>
+                          <li class="nav-item nav-course-settings-schedule">
+                            <a href="${settings_url}">${_("Schedule & Details")}</a>
+                          </li>
+                          <li class="nav-item nav-course-settings-grading">
+                            <a href="${grading_url}">${_("Grading")}</a>
+                          </li>
+                          <li class="nav-item nav-course-settings-team">
+                            <a href="${course_team_url}">${_("Course Team")}</a>
+                          </li>
+                          <li class="nav-item nav-course-settings-group-configurations">
+                            <a href="${reverse('contentstore.views.group_configurations_list_handler', kwargs={'course_key_string': unicode(course_key)})}">${_("Group Configurations")}</a>
+                          </li>
+                          <li class="nav-item nav-course-settings-advanced">
+                            <a href="${advanced_settings_url}">${_("Advanced Settings")}</a>
+                          </li>
+                          % if certificates_url:
+                          <li class="nav-item nav-course-settings-certificates">
+                            <a href="${certificates_url}">${_("Certificates")}</a>
+                          </li>
+                          % endif
+                        </ul>
+                      </div>
+                    </div>
                   </li>
-                  <li class="nav-item nav-course-settings-grading">
-                    <a href="${grading_url}">${_("Grading")}</a>
-                  </li>
-                  <li class="nav-item nav-course-settings-team">
-                    <a href="${course_team_url}">${_("Course Team")}</a>
-                  </li>
-                  <li class="nav-item nav-course-settings-group-configurations">
-                    <a href="${reverse('contentstore.views.group_configurations_list_handler', kwargs={'course_key_string': unicode(course_key)})}">${_("Group Configurations")}</a>
-                  </li>
-                  <li class="nav-item nav-course-settings-advanced">
-                    <a href="${advanced_settings_url}">${_("Advanced Settings")}</a>
-                  </li>
-                  % if certificates_url:
-                  <li class="nav-item nav-course-settings-certificates">
-                    <a href="${certificates_url}">${_("Certificates")}</a>
-                  </li>
-                  % endif
-                </ul>
-              </div>
-            </div>
-          </li>
 
-          <li class="nav-item nav-course-tools">
-            <h3 class="title"><span class="label">${_("Tools")}</span> <span class="icon fa fa-caret-down ui-toggle-dd" aria-hidden="true"></span></h3>
-            <div class="wrapper wrapper-nav-sub">
-              <div class="nav-sub">
-                <ul>
-                  <li class="nav-item nav-course-tools-import">
-                    <a href="${import_url}">${_("Import")}</a>
+                  <li class="nav-item nav-course-tools">
+                    <h3 class="title"><span class="label">${_("Tools")}</span> <span class="icon fa fa-caret-down ui-toggle-dd" aria-hidden="true"></span></h3>
+                    <div class="wrapper wrapper-nav-sub">
+                      <div class="nav-sub">
+                        <ul>
+                          <li class="nav-item nav-course-tools-import">
+                            <a href="${import_url}">${_("Import")}</a>
+                          </li>
+                          <li class="nav-item nav-course-tools-export">
+                            <a href="${export_url}">${_("Export")}</a>
+                          </li>
+                          % if settings.FEATURES.get('ENABLE_EXPORT_GIT') and context_course.giturl:
+                          <li class="nav-item nav-course-tools-export-git">
+                            <a href="${reverse('export_git', kwargs=dict(course_key_string=unicode(course_key)))}">${_("Export to Git")}</a>
+                          </li>
+                          % endif
+                        </ul>
+                      </div>
+                    </div>
                   </li>
-                  <li class="nav-item nav-course-tools-export">
-                    <a href="${export_url}">${_("Export")}</a>
-                  </li>
-                  % if settings.FEATURES.get('ENABLE_EXPORT_GIT') and context_course.giturl:
-                  <li class="nav-item nav-course-tools-export-git">
-                    <a href="${reverse('export_git', kwargs=dict(course_key_string=unicode(course_key)))}">${_("Export to Git")}</a>
-                  </li>
-                  % endif
-                </ul>
-              </div>
-            </div>
-          </li>
-        </ol>
-      </nav>
-           %endif
+                </ol>
+                </nav>
+          %endif
       % elif context_library:
        <%
             library_key = context_library.location.course_key

--- a/cms/templates/widgets/header.html
+++ b/cms/templates/widgets/header.html
@@ -10,9 +10,15 @@
   <header class="primary" role="banner">
 
     <div class="wrapper wrapper-l">
-      <h1 class="branding"><a href="/">
-        <img src="${static.url('images/studio-logo.png')}" alt="${settings.STUDIO_NAME}" />
-      </a></h1>
+      <h1 class="branding">
+          %if user.is_staff:
+            <a href="/">
+          %else:
+            <a href="">
+          %endif
+                <img src="${static.url('images/studio-logo.png')}" alt="${settings.STUDIO_NAME}" />
+            </a>
+      </h1>
 
       % if context_course:
       <%
@@ -35,13 +41,18 @@
       %>
       <h2 class="info-course">
         <span class="sr">${_("Current Course:")}</span>
-        <a class="course-link" href="${index_url}">
+        %if user.is_staff:
+            <a class="course-link" href="${index_url}">
+        %else:
+            <a class="course-link" href="">
+        %endif
           <span class="course-org">${context_course.display_org_with_default}</span><span class="course-number">${context_course.display_number_with_default}</span>
           <span class="course-title" title="${context_course.display_name_with_default}">${context_course.display_name_with_default}</span>
         </a>
       </h2>
-
-      <nav class="nav-course nav-dd ui-left" aria-label="${_('Course')}">
+##         MIT override
+          %if user.is_staff:
+          <nav class="nav-course nav-dd ui-left" aria-label="${_('Course')}">
         <h2 class="sr">${_("Course Navigation")}</h2>
         <ol>
           <li class="nav-item nav-course-courseware">
@@ -128,6 +139,7 @@
           </li>
         </ol>
       </nav>
+           %endif
       % elif context_library:
        <%
             library_key = context_library.location.course_key


### PR DESCRIPTION
1. Remove un-customizable blocks from the dropdown list 
2. Disable the unit name edit function 
3. Hide the 'Content Setting Tools' menus 
4. Add an advisory note on under the Publish button with the note.
