### PR TITLE
Hide #main from LMS

### DIFF
--- a/lms/static/sass/_mit-cre-overrides.scss
+++ b/lms/static/sass/_mit-cre-overrides.scss
@@ -61,6 +61,10 @@ $breakSmall: 1024px;
 }
 
 /* EDX overrides */
+.view-in-course.courseware .nav-skip {
+  display: none;
+}
+
 .course-wrapper {
   position: absolute;
   overflow: auto;


### PR DESCRIPTION
- hide "skip to nav" anchor while navigating through content via keyboard.